### PR TITLE
add: 관리자 쿼리 추가

### DIFF
--- a/src/resolvers/resolver.ts
+++ b/src/resolvers/resolver.ts
@@ -4,7 +4,7 @@ import { IResolvers } from 'apollo-server-koa';
 import * as redis from 'redis';
 import * as uuid from 'uuid';
 
-import { transaction, user } from '../models';
+import { transaction, user, booth } from '../models';
 import * as sequelize from 'sequelize';
 
 const client = redis.createClient({
@@ -13,6 +13,39 @@ const client = redis.createClient({
 
 const resolver: IResolvers = {
     Query: {
+        me: async (_, __, { ctx }) => ctx.user,
+        users: async (_, __, { ctx }) => {
+            if (!ctx.user) return null;
+
+            const users = await user.findAll();
+
+            return users;
+        },
+        booth: async (_, { bid }, { ctx }) => {
+            if (!ctx.user) return null;
+
+            const _booth = await booth.findOne({
+                where: {
+                    bid: bid,
+                },
+            });
+
+            return _booth;
+        },
+        booths: async (_, __, { ctx }) => {
+            if (!ctx.user) return null;
+
+            const booths = await booth.findAll();
+
+            return booths;
+        },
+        transactions: async (_, __, { ctx }) => {
+            if (!ctx.user) return null;
+
+            const transactions = await transaction.findAll();
+
+            return transactions;
+        },
         transactionsInBooth: async (_, { bid }, { ctx }) => {
             if (!ctx.user) return null;
 
@@ -29,13 +62,13 @@ const resolver: IResolvers = {
 
             const user = ctx.user;
 
-            const transcations = await transaction.findAll({
+            const transactions = await transaction.findAll({
                 where: {
                     pid: user.pid,
                 }
             });
 
-            return transcations;
+            return transactions;
         }
     },
     Mutation: {

--- a/src/typeDefs/query.ts
+++ b/src/typeDefs/query.ts
@@ -2,8 +2,13 @@ import { gql } from 'apollo-server-koa';
 
 const query = gql`
     type Query {
+        me: User
+        users: [User]
+        booth(bid: Int!): Booth
+        booths: [Booth]
         transactionsInBooth(bid: Int): [Transaction]
         transactionsInUser: [Transaction]
+        transactions: [Transaction]
     }
 `;
 


### PR DESCRIPTION
관리자 클라이언트에서 서버에 요청해야 할 데이터에 대해서 더 추가해야 할 쿼리 기능을 추가한 PR입니다. 아래 쿼리가 추가될 예정입니다.

```GraphQL
me: User => 현재 로그인된 유저
users: [User]
booth(bid: Int!): Booth
booths: [Booth]
transactions: [Transaction]
```